### PR TITLE
fix: 메세지 범위 넘겼을 때 에러 수정

### DIFF
--- a/src/components/chat-room/Test.tsx
+++ b/src/components/chat-room/Test.tsx
@@ -1,0 +1,47 @@
+import styled from 'styled-components';
+import React from 'react';
+
+const formatMessage = (text: string) => {
+  return text.split('\n').map((line, index) => (
+    <React.Fragment key={index}>
+      {line}
+      <br />
+    </React.Fragment>
+  ));
+};
+
+const text = `
+ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ
+`;
+
+const Test = () => {
+  return (
+    <TestStyle>
+      <div className="nickname">{'테스트'}</div>
+      <div className="user-message">{formatMessage(text)}</div>
+    </TestStyle>
+  );
+};
+
+const TestStyle = styled.div`
+  .nickname {
+    font-size: 0.75rem;
+    font-weight: medium;
+    margin-bottom: 4px;
+    color: white;
+  }
+
+  .user-message {
+    background: #D0D5F3
+    width: auto;
+    max-width: 90%;
+    word-wrap: break-word; /* 단어가 길 경우 줄바꿈 */
+    word-break: break-word; /* 영어 등 긴 단어가 있을 경우 강제 줄바꿈 */
+    white-space: pre-wrap; /* 줄바꿈(\n) 적용 */
+    border-radius: 4px;
+    padding: 6px;
+    font-size: 0.9rem;
+  }
+`;
+
+export default Test;

--- a/src/components/chat-room/UserMessage.tsx
+++ b/src/components/chat-room/UserMessage.tsx
@@ -36,7 +36,7 @@ const MessageStyle = styled.div<MessageStyleProps>`
   flex-direction: column;
   align-items: ${({ $me }) => ($me ? 'flex-end' : 'flex-start')};
 
-  padding: 16px;
+  padding: 14px;
 
   .nickname {
     font-size: 0.75rem;
@@ -46,8 +46,12 @@ const MessageStyle = styled.div<MessageStyleProps>`
   }
 
   .user-message {
-    background: ${({ $me }) => ($me ? '#D9D9D9' : '#D0D5F3')};
-    width: 65%;
+    background: #D0D5F3
+    width: auto;
+    max-width: 90%;
+    word-wrap: break-word;
+    word-break: break-word; 
+    white-space: pre-wrap;
     border-radius: 4px;
     padding: 6px;
     font-size: 0.9rem;

--- a/src/views/Index.tsx
+++ b/src/views/Index.tsx
@@ -19,9 +19,11 @@ import FindPassword from '../components/login/FindPassword';
 import EmailDuplicateTest from '../components/register/email-verify/EmailDuplicateTest';
 import ChatRoom from './pages/ChatRoom';
 import CreateRoom from './pages/CreateRoom';
+import Test from '../components/chat-room/Test';
 
 const Index = () => {
   const routeLists = [
+    { path: '/test', element: <Test />, noNav: true },
     {
       path: '/',
       element: <Home />,


### PR DESCRIPTION
## #️⃣ 연관된 이슈 (선택)

close #60 

## 📝 작업 내용

- 메세지 컴포넌트의 길이를 가변적으로 설정
- 유저 메세지가 길어도 글자가 컴포넌트 밖으로 나오지 않도록 수정

## 💬 리뷰 요구사항(선택)

